### PR TITLE
#10 user story 09 (Move Celery tasks to API endpoints)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ django-debug-toolbar = "*"
 pudb = "*"
 isort = "*"
 django-select2 = "*"
+pre-commit = "*"
 
 [packages]
 django-rest-swagger = "==2.1.2"

--- a/aided_tournament_system/config/settings/local.py
+++ b/aided_tournament_system/config/settings/local.py
@@ -38,8 +38,8 @@ SWAGGER_SETTINGS = {
             }
         },
         'USE_SESSION_AUTH': False,
-        'LOGIN_URL': 'rest_framework:login',
-        'LOGOUT_URL': 'rest_framework:logout'
+        'LOGIN_URL': 'api_user:login',
+        'LOGOUT_URL': 'api_user:logout'
     }
 
 

--- a/aided_tournament_system/features/competition/steps/competition_create.py
+++ b/aided_tournament_system/features/competition/steps/competition_create.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from behave import given, then, when
 from features.utils import api_post
 from game.models import Game
+from participant.models import Referee
 from user_auth.models import User
 
 
@@ -17,6 +18,19 @@ def create_superuser(context, email, password, is_superuser, is_staff):
         is_superuser=literal_eval(is_superuser),
         is_staff=literal_eval(is_staff)
     )
+
+
+@given('Referee with First name: {first_name}, Last name: {last_name}, '
+       'username: {username}, email: {email}, password: {password}.')
+def create_referee(context, first_name, last_name, username, email, password):
+    user = User.objects.create_superuser(
+        username=username,
+        password=password,
+        email=email,
+        first_name=first_name,
+        last_name=last_name
+    )
+    Referee.objects.create(user=user)
 
 
 @when('User creates competition with valid data')

--- a/aided_tournament_system/features/participant/list_participant.feature
+++ b/aided_tournament_system/features/participant/list_participant.feature
@@ -6,17 +6,22 @@ Feature: Look participant
     Given User with email: test and password: top_secure, superuser: True, staff: True.
 
     And Team with players
-    |first_name|last_name|username      |email        |password   |
-    |Masha     |Test     |test1         |test@test.com|top_secure1|
-    |Misha     |Test     |test2         |test@test.com|top_secure2|
+    |first_name|last_name|username      |email        |password   |beach_rating|
+    |Masha     |Test     |test1         |test@test.com|top_secure1|5           |
+    |Misha     |Test     |test2         |test@test.com|top_secure2|12          |
+
+    And Referee with First name: Sergey, Last name: Pupkin, username: pupkin, email: test@test.com, password: top_secure3.
 
     When User check list of teams
+    Then Get teams info correct
     Then Status code is 200
 
     When User check list of referees
+    Then Get referee info correct
     Then Status code is 200
 
     When User check list of players
+    Then Get users info correct
     Then Status code is 200
 
     When User check list of players for a Team

--- a/aided_tournament_system/features/participant/steps/list_participants.py
+++ b/aided_tournament_system/features/participant/steps/list_participants.py
@@ -1,20 +1,30 @@
-from behave import given, when
+from behave import given, then, when
+from competition.choices import CompetitionTypeChoices
 from features.utils import api_get
-from participant.models import Player, Team
+from participant.models import Player, Rating, Team
 from user_auth.models import User
 
 
 @given('{team_title} with players')
 def create_team_with_players(context, team_title):
     team = Team.objects.create(title=team_title)
+    ratings = 0
     for row in context.table:
+        rating = Rating.objects.create(
+            type=CompetitionTypeChoices.BEACH_VOLLEY.value,
+            points=int(row['beach_rating'])
+        )
         user = User.objects.create_user(username=row['username'],
                                         email=row['email'],
                                         password=row['password'],
                                         first_name=row['first_name'],
                                         last_name=row['last_name'])
-        player = Player.objects.create(user_id=user.id)
+        player = Player.objects.create(user=user)
+        player.rating.add(rating)
+        ratings += rating.points
         player.team.add(team)
+    team.rating = ratings
+    team.save()
 
 
 @when('User check list of teams')
@@ -27,14 +37,14 @@ def get_list_teams(context):
 @when('User check list of referees')
 def get_list_referees(context):
     context.response = api_get(
-        '/api/participant/team/detail/',
+        '/api/participant/referee/detail/',
         context.user)
 
 
 @when('User check list of players')
 def get_list_players(context):
     context.response = api_get(
-        '/api/participant/team/detail/',
+        '/api/participant/player/detail/',
         context.user)
 
 
@@ -44,3 +54,48 @@ def get_players_for_a_team(context, team):
         f'/api/participant/{team}/players/',
         context.user
     )
+
+
+@then('Get teams info correct')
+def get_team_list(context):
+    data = context.response.json()
+    assert data[0]['title'] == 'Team'
+    assert data[0]['rating'] == 17
+    assert data[0]['players'][0]['user']['first_name'] == 'Masha'
+    assert data[0]['players'][1]['user']['first_name'] == 'Misha'
+    assert data[0]['players'][0]['user']['username'] == 'test1'
+    assert data[0]['players'][1]['user']['username'] == 'test2'
+    assert data[0]['players'][0]['user']['last_name'] == 'Test'
+    assert data[0]['players'][1]['user']['last_name'] == 'Test'
+    assert data[0]['players'][0]['user']['email'] == 'test@test.com'
+    assert data[0]['players'][1]['user']['email'] == 'test@test.com'
+    assert data[0]['players'][0]['rating'][0]['type'] == 'Beach'
+    assert data[0]['players'][1]['rating'][0]['type'] == 'Beach'
+    assert data[0]['players'][0]['rating'][0]['points'] == 5
+    assert data[0]['players'][1]['rating'][0]['points'] == 12
+
+
+@then('Get referee info correct')
+def get_referee_list(context):
+    data = context.response.json()
+    assert data[0]['user']['first_name'] == 'Sergey'
+    assert data[0]['user']['last_name'] == 'Pupkin'
+    assert data[0]['user']['username'] == 'pupkin'
+    assert data[0]['user']['email'] == 'test@test.com'
+
+
+@then('Get users info correct')
+def get_players_list(context):
+    data = context.response.json()
+    assert data[0]['user']['first_name'] == 'Masha'
+    assert data[1]['user']['first_name'] == 'Misha'
+    assert data[0]['user']['username'] == 'test1'
+    assert data[1]['user']['username'] == 'test2'
+    assert data[0]['user']['last_name'] == 'Test'
+    assert data[1]['user']['last_name'] == 'Test'
+    assert data[0]['user']['email'] == 'test@test.com'
+    assert data[1]['user']['email'] == 'test@test.com'
+    assert data[0]['rating'][0]['type'] == 'Beach'
+    assert data[1]['rating'][0]['type'] == 'Beach'
+    assert data[0]['rating'][0]['points'] == 5
+    assert data[1]['rating'][0]['points'] == 12

--- a/aided_tournament_system/participant/api/serializers.py
+++ b/aided_tournament_system/participant/api/serializers.py
@@ -1,32 +1,42 @@
-from participant.models import Player, Referee, Team
+from participant.models import Player, Rating, Referee, Team
 from rest_framework import serializers
+from user_auth.api.serializers import UserSerializer
+
+
+class RatingSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Rating
+        fields = ['id', 'type', 'points']
+        read_only_fileds = ['id']
 
 
 class PlayerListSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+    rating = RatingSerializer(many=True)
+
     class Meta:
         model = Player
-        fields = ['id', 'rating']
+        fields = ['id', 'rating', 'user']
         read_only_fields = ['id']
 
 
 class RefereeListSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+
     class Meta:
         model = Referee
-        fields = ['id']
-        read_only_fields = ['id']
+        fields = ['id', 'user']
+        read_only_fields = ['id', 'user']
 
 
 class TeamListSerializer(serializers.ModelSerializer):
+    players = PlayerListSerializer(many=True)
+
     class Meta:
         model = Team
-        fields = ['id', 'title', 'rating']
+        fields = ['id', 'title', 'rating', 'players']
         read_only_fields = ['id']
-
-
-class PlayerInTeamListSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Player
-        fields = ['last_name', 'first_name', 'team.title']
 
 
 class PlayerCreateSerializer(serializers.ModelSerializer):

--- a/aided_tournament_system/participant/api/urls.py
+++ b/aided_tournament_system/participant/api/urls.py
@@ -18,11 +18,6 @@ urlpatterns = [
         name='team_list'
     ),
     url(
-        regex=r'^team/(?P<title>.+)/players/$',
-        view=views.PlayersInTeamsListAPIView.as_view(),
-        name='players_in_team'
-    ),
-    url(
         regex=r'^player/add/$',
         view=views.PlayerCreateAPIView.as_view(),
         name='add_player_role'

--- a/aided_tournament_system/participant/api/views.py
+++ b/aided_tournament_system/participant/api/views.py
@@ -1,4 +1,5 @@
 from participant.models import Player, Referee, Team
+from participant.tasks import add_rating_to_player_task
 from rest_framework import status
 from rest_framework.generics import CreateAPIView, ListAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -31,7 +32,8 @@ class PlayerCreateAPIView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        Player.objects.create(user=request.user)
+        player = Player.objects.create(user=request.user)
+        add_rating_to_player_task.apply_async((player,))
         return Response(data={'detail': 'Player has successfully created.'},
                         status=status.HTTP_201_CREATED)
 
@@ -59,5 +61,5 @@ class PlayerJoinToTeamAPIView(APIView):
         player.save()
         player.team.add(team)
         return Response(data={
-            'detail': f'You successfully added to {team.title}.'
+            'detail': f'You successfully added to team with id {team_id}.'
         })

--- a/aided_tournament_system/participant/api/views.py
+++ b/aided_tournament_system/participant/api/views.py
@@ -5,9 +5,8 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import (PlayerInTeamListSerializer, PlayerListSerializer,
-                          RefereeListSerializer, TeamCreateSerializer,
-                          TeamListSerializer)
+from .serializers import (PlayerListSerializer, RefereeListSerializer,
+                          TeamCreateSerializer, TeamListSerializer)
 
 
 class PlayerListAPIView(ListAPIView):
@@ -28,20 +27,11 @@ class TeamListAPIView(ListAPIView):
     serializer_class = TeamListSerializer
 
 
-class PlayersInTeamsListAPIView(ListAPIView):
-    permission_classes = (AllowAny,)
-    serializer_class = PlayerInTeamListSerializer
-
-    def get_queryset(self):
-        title = self.kwargs['title']
-        return Player.objects.filter(team__title=title)
-
-
 class PlayerCreateAPIView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        Player.objects.create(user_id=request.user.id)
+        Player.objects.create(user=request.user)
         return Response(data={'detail': 'Player has successfully created.'},
                         status=status.HTTP_201_CREATED)
 
@@ -50,7 +40,7 @@ class RefereeCreateAPIView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        Referee.objects.create(user_id=request.user.id)
+        Referee.objects.create(user=request.user)
         return Response(data={'detail': 'Referee has successfully created.'},
                         status=status.HTTP_201_CREATED)
 
@@ -65,7 +55,7 @@ class PlayerJoinToTeamAPIView(APIView):
 
     def put(self, request, team_id):
         team = Team.objects.get(id=team_id)
-        player = Player.objects.get(user_id=request.user.id)
+        player = Player.objects.get(user=request.user)
         player.save()
         player.team.add(team)
         return Response(data={

--- a/aided_tournament_system/participant/models.py
+++ b/aided_tournament_system/participant/models.py
@@ -3,25 +3,30 @@ from django.db import models
 from django_utils.models import UUIDTimeStampModel
 from game.models import Game
 from participant.choices import RefereeRoles
-from user_auth.services import get_user_by_id
+from user_auth.models import User
 
 from .managers import PlayerManager
 
 
 class Player(UUIDTimeStampModel):
-    user_id = models.UUIDField(verbose_name='users uuid', unique=True)
+    user = models.ForeignKey('user_auth.User',
+                             on_delete=models.CASCADE,
+                             blank=True,
+                             null=True,
+                             verbose_name='user',
+                             related_name='players')
     rating = models.ManyToManyField('Rating',
                                     blank=True,
                                     verbose_name='rating',
-                                    related_name='ratings')
+                                    related_name='players')
     team = models.ManyToManyField('Team',
                                   blank=True,
-                                  verbose_name='team')
+                                  verbose_name='team',
+                                  related_name='players')
     objects = PlayerManager()
 
     def __str__(self):
-        user = get_user_by_id(self.user_id)
-        return f'{user.last_name} {user.first_name}'
+        return f'{self.user.last_name} {self.user.first_name}'
 
     class Meta:
         db_table = 'player'
@@ -51,15 +56,18 @@ class Team(UUIDTimeStampModel):
 
 
 class Referee(UUIDTimeStampModel):
-    user_id = models.UUIDField(verbose_name='users uuid', unique=True)
+    user = models.ForeignKey(User,
+                             on_delete=models.SET_NULL,
+                             blank=True,
+                             null=True,
+                             related_name='referees')
     game = models.ManyToManyField(Game)
     role = models.CharField(max_length=3,
                             choices=RefereeRoles.get_choices(),
                             verbose_name='role')
 
     def __str__(self):
-        user = get_user_by_id(self.user_id)
-        return f'{user.first_name} {user.last_name}'
+        return f'{self.user.first_name} {self.user.last_name}'
 
     class Meta:
         db_table = 'referee'

--- a/aided_tournament_system/participant/tasks.py
+++ b/aided_tournament_system/participant/tasks.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import, unicode_literals
 from uuid import UUID
 
 from celery import shared_task
-from participant.models import Player, Referee, Team
+from participant.models import Player, Team
 from participant.services.add_rating_to_player import add_rating_to_player
 from participant.services.recalculating_player_rating import recalculate_rating
+from user_auth.models import User
 
 
 @shared_task
@@ -14,19 +15,13 @@ def recalculate_rating_task(competition_type: str):
 
 
 @shared_task
-def create_referee_task(user_id: UUID):
-    Referee.objects.create(user_id=user_id)
-
-
-@shared_task
-def create_player_task(user_id: UUID):
-    player = Player.objects.create(user_id=user_id)
+def add_rating_to_player_task(player: Player):
     add_rating_to_player(player)
 
 
 @shared_task
-def player_join_team_task(team_id: UUID, user_id: UUID):
+def player_join_team_task(team_id: UUID, user: User):
     team = Team.objects.get(id=team_id)
-    player = Player.objects.get(user_id=user_id)
+    player = Player.objects.get(user=user)
     player.save()
     player.team.add(team)

--- a/aided_tournament_system/participant/views.py
+++ b/aided_tournament_system/participant/views.py
@@ -40,7 +40,7 @@ class RatingView(RatingChoiceView):
 class RefereeCreateView(View):
 
     def post(self, request):
-        create_referee_task.apply_async((request.user.id,))
+        create_referee_task.apply_async((request.user,))
         return redirect('/user/detail/')
 
 

--- a/aided_tournament_system/user_auth/api/serializers.py
+++ b/aided_tournament_system/user_auth/api/serializers.py
@@ -8,6 +8,7 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ['first_name',
                   'last_name',
+                  'username',
                   'email']
 
 


### PR DESCRIPTION
## The main issue of this PR is to move all views of the API to celery task where it is possible

**Pits and following issues:**
- Was not convenient way of displaying players (was refactored player and referee model with replacing user_id to ForeignKey to User model)
- Updated login and logout swagger urls
- Updated all serializers for participants
- Updated tests for list endpoints for participants